### PR TITLE
タスク追加機能の作成

### DIFF
--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -31,6 +31,8 @@
       
     .mein-wrapper{
        padding-top: 30px;
+       width: 100vw;
+       height: 100vh;
        background-color: rgba(250, 223, 169, 0.5);
        margin-bottom: 0px;
      

--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -31,8 +31,6 @@
       
     .mein-wrapper{
        padding-top: 30px;
-       width: 100vw;
-       height: 100vh;
        background-color: rgba(250, 223, 169, 0.5);
        margin-bottom: 0px;
      
@@ -54,7 +52,9 @@
           input{
             display: none;
           }
-          p{
+          a{
+            text-decoration: none;
+            color: black;
             font-size: 20px;
             position: absolute;
             top: 17px;

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,6 @@
 class PostsController < ApplicationController
   def index
+    @posts = Post.all.order(created_at: :desc)
   end
 
   def new

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,5 +3,23 @@ class PostsController < ApplicationController
   end
 
   def new
+    @post = Post.new
+  # 空のpostインスタンスを生成する
   end
+
+  def create
+    @post = Post.new(post_params)
+  # newページで入力した内容が格納された状態のインスタンスが飛んでくる
+    if @post.save
+      redirect_to posts_path
+    else
+      render 'new'
+    end
+  end
+
+  private
+  def post_params
+    params.require(:post).permit(:task, :emphasis, :labor, :classification)
+  end
+
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -11,15 +11,18 @@
 
       <div class="mein-wrapper">
        <div class="task-wrapper">
-         <div class="field">
-           <label for="radio-1" class="radio-label">
-           <%= image_tag("/photo/check-btn.png", class:"check", :size => "50x50")%>
-           <input id="radio-1" type="radio" name="radio" value="お風呂そうじ"/>
-           <div class="task">
-             <p>お風呂そうじ</p>
-           </div>
-           </label>
-         </div>
+       <% @posts.each do |post| %>
+        <div class="field">
+          <label for="radio-1" class="radio-label">
+            <%= image_tag("/photo/check-btn.png", class:"check", :size => "50x50")%>
+            
+            <input id="radio-1" type="radio" name="radio" value=<% post.task %> />
+            <div class="task">
+              <%= link_to post.task, new_post_path %>
+            </div>
+          </label>
+        </div>
+        <% end %>
        </div>
 
        <div class="done-wrapper">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -63,7 +63,6 @@
 
 
         <%= link_to "Log out", destroy_user_session_path, class: "#", data: { turbo_method: :delete, turbo_confirm: " 本当にログアウトしますか？"} %>
-      </div>
   </div>
 </div>
 

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -9,13 +9,13 @@
   </header>
   <div class="mein-wrapper">
     <div class="formbox">
-      <%= form_with url: posts_path do |form| %>
+      <%= form_with url: posts_path, scope: :post do |form| %>
         <div class="form-1">
           <%=form.label :task, "タスク名" %><br>
           <%=form.text_field :task %>
         </div>
           <div class="check-box">
-            <%= check_box_tag :test1 %>
+            <%= form.check_box :emphasis, {}, "true", "false" %>
             <p>重要（タスクが強調されます）</p>
           </div>
 

--- a/db/migrate/20230613131914_add_classification_to_posts.rb
+++ b/db/migrate/20230613131914_add_classification_to_posts.rb
@@ -1,0 +1,5 @@
+class AddClassificationToPosts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :posts, :classification, :string, null: false
+  end
+end

--- a/db/migrate/20230613135257_change_datatype_emphasis_of_posts.rb
+++ b/db/migrate/20230613135257_change_datatype_emphasis_of_posts.rb
@@ -1,0 +1,5 @@
+class ChangeDatatypeEmphasisOfPosts < ActiveRecord::Migration[7.0]
+  def change
+    change_column :posts, :emphasis, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20230613142324_change_datatype_emphasis_of_posts2.rb
+++ b/db/migrate/20230613142324_change_datatype_emphasis_of_posts2.rb
@@ -1,0 +1,5 @@
+class ChangeDatatypeEmphasisOfPosts2 < ActiveRecord::Migration[7.0]
+  def change
+    change_column :posts, :emphasis, :boolean, default: false
+  end
+end

--- a/db/migrate/20230613144543_change_datatype_emphasis_of_posts3.rb
+++ b/db/migrate/20230613144543_change_datatype_emphasis_of_posts3.rb
@@ -1,0 +1,13 @@
+class ChangeDatatypeEmphasisOfPosts3 < ActiveRecord::Migration[7.0]
+  def change
+    def up
+      #change_column :テーブル名, :型を変更したいカラム名, :変更後のデータ型
+      change_column :posts, :emphasis, :boolean, default: false
+     end
+   
+     def down
+      #change_column :テーブル名, :型を戻すカラム名, :変更前のデータ型
+      change_column :posts, :emphasis, :boolean, default: false, null: false
+     end
+  end
+end

--- a/db/migrate/20230613145106_change_datatype_emphasis_of_posts4.rb
+++ b/db/migrate/20230613145106_change_datatype_emphasis_of_posts4.rb
@@ -1,0 +1,11 @@
+class ChangeDatatypeEmphasisOfPosts4 < ActiveRecord::Migration[7.0]
+  def change
+    def up
+      change_column :posts, :emphasis, :boolean, default: false
+     end
+   
+     def down
+      change_column :posts, :emphasis, :boolean, default: false, null: false
+     end
+  end
+end

--- a/db/migrate/20230613150641_remove_emphasis_from_posts.rb
+++ b/db/migrate/20230613150641_remove_emphasis_from_posts.rb
@@ -1,0 +1,5 @@
+class RemoveEmphasisFromPosts < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :posts, :emphasis, :boolean
+  end
+end

--- a/db/migrate/20230613151522_add_emphasis_to_posts.rb
+++ b/db/migrate/20230613151522_add_emphasis_to_posts.rb
@@ -1,0 +1,5 @@
+class AddEmphasisToPosts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :posts, :emphasis, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_13_113848) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_13_131914) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -49,6 +49,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_13_113848) do
     t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "classification", null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_13_131914) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_13_151522) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -44,12 +44,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_13_131914) do
 
   create_table "posts", force: :cascade do |t|
     t.string "task", null: false
-    t.boolean "emphasis"
     t.integer "labor", default: 1, null: false
     t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "classification", null: false
+    t.boolean "emphasis", default: false, null: false
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
【内容】
タスク追加画面（posts/new.html）から追加したタスクをpostsテーブルに保存して
todo画面（posts/index.html）に表示する。
※上二つのコミットでpostsテーブルを作成していますがここは見なくて大丈夫です。
※タスクの分類は４つありますが、今回は通常のタスクの追加のみをまずは作成しています。

【確認手順】

- [ ] 　todo画面（posts/index.html）の右下のプラス画像をクリックすると、タスク追加画面（posts/new.html）に画面遷移。

- [ ] タスク追加画面（posts/new.html）で各項目を入力後、タスクを追加するをクリックしたらDB（postsテーブル）に保存後、todo画面（posts/index.html）に画面遷移。[c4a71b2](https://github.com/kazuki-01/family/pull/11/commits/c4a71b2dd51ff006d86826af1022a8d50d6f291b)

- [ ] DB（postsテーブル）のタスクを新しい順に表示させる。[f5194a9](https://github.com/kazuki-01/family/pull/11/commits/f5194a9127ae516ce301548027e8fce262c11663)