### PR TITLE
毎日•曜日指定のタスク追加機能を作成

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -17,6 +17,17 @@ class PostsController < ApplicationController
     else
       render 'new'
     end
+
+    wday = Weekly.new(task: post.task, emphasis: post.emphasis, labor: post.labor, classification: post.classification, day_of_week: params[:day_of_week])
+    if wday.classification == "generally"
+    elsif wday.classification == "week"
+      wday.save
+    elsif wday.classification == "everyday"
+      wday.day_of_week = '["1", "2", "3", "4", "5", "6", "0"]'
+      wday.save
+    else
+      Rails.logger.debug('aaaaa')
+    end
   end
 
   def edit

--- a/app/models/weekly.rb
+++ b/app/models/weekly.rb
@@ -1,0 +1,2 @@
+class Weekly < ApplicationRecord
+end

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -39,6 +39,22 @@
           <label><%= form.radio_button :classification, :week%>曜日指定のタスク</label>
           <p>※指定した曜日にタスクが<br>
             &emsp;自動で追加されます。<font color="red">（有料）</font></p>
+          <div>
+            <input id="monday" name="day_of_week[]" type="checkbox" value="1">
+            <label for="monday">月</label>
+            <input id="tuesday" name="day_of_week[]" type="checkbox" value="2">
+            <label for="tuesday">火</label>
+            <input id="wednesday" name="day_of_week[]" type="checkbox" value="3">
+            <label for="wednesday">水</label>
+            <input id="thursday" name="day_of_week[]" type="checkbox" value="4">
+            <label for="thursday">木</label>
+            <input id="friday" name="day_of_week[]" type="checkbox" value="5">
+            <label for="friday">金</label>
+            <input id="saturday" name="day_of_week[]" type="checkbox" value="6">
+            <label for="saturday">土</label>
+            <input id="sunday" name="day_of_week[]" type="checkbox" value="0">
+            <label for="sunday">日</label>
+          </div>
         </div>
       </div>
 

--- a/db/migrate/20230712045355_create_weeklies.rb
+++ b/db/migrate/20230712045355_create_weeklies.rb
@@ -1,0 +1,12 @@
+class CreateWeeklies < ActiveRecord::Migration[7.0]
+  def change
+    create_table :weeklies do |t|
+      t.string :task, null: false
+      t.integer :labor, null: false
+      t.string :classification, null: false
+      t.integer :day_of_week, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230712063922_add_emphasis_to_weekly.rb
+++ b/db/migrate/20230712063922_add_emphasis_to_weekly.rb
@@ -1,0 +1,5 @@
+class AddEmphasisToWeekly < ActiveRecord::Migration[7.0]
+  def change
+    add_column :weeklies, :emphasis, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20230712142328_change_datatype_day_of_week_of_weeklies.rb
+++ b/db/migrate/20230712142328_change_datatype_day_of_week_of_weeklies.rb
@@ -1,0 +1,5 @@
+class ChangeDatatypeDayOfWeekOfWeeklies < ActiveRecord::Migration[7.0]
+  def change
+    change_column :weeklies, :day_of_week, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_12_063922) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_12_142328) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -78,7 +78,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_12_063922) do
     t.string "task", null: false
     t.integer "labor", null: false
     t.string "classification", null: false
-    t.integer "day_of_week", null: false
+    t.string "day_of_week", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "emphasis", default: false, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_03_202312) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_12_063922) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -72,6 +72,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_03_202312) do
     t.string "name"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  end
+
+  create_table "weeklies", force: :cascade do |t|
+    t.string "task", null: false
+    t.integer "labor", null: false
+    t.string "classification", null: false
+    t.integer "day_of_week", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.boolean "emphasis", default: false, null: false
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/test/fixtures/weeklies.yml
+++ b/test/fixtures/weeklies.yml
@@ -1,0 +1,13 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  task: MyString
+  labor: 1
+  classification: MyString
+  day_of_week: 1
+
+two:
+  task: MyString
+  labor: 1
+  classification: MyString
+  day_of_week: 1

--- a/test/models/weekly_test.rb
+++ b/test/models/weekly_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class WeeklyTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
【内容】
毎日のタスクは、postsテーブルに登録後、weekliesテーブルにタスク情報＋day_of_week(曜日の情報※0〜6全て)を登録
最終的には、日付が変わったら自動的にタスクを追加するようにする。

曜日指定のタスクは、postsテーブルに登録後、weekliesテーブルにタスク情報＋day_of_week(曜日の情報※0〜6)を登録
最終的には、指定した曜日に毎週自動的にタスクを追加するようにする。
【確認方法】
