### PR TITLE
タスクの投稿のviewの編集

### DIFF
--- a/app/assets/stylesheets/posts.scss
+++ b/app/assets/stylesheets/posts.scss
@@ -220,14 +220,29 @@
           input {
             width: 25px;
             height: 25px;
-            margin: 20px 20px 20px 5px;
+            margin: 20px 10px 20px 5px;
           }
           label{
             font-size: 25px;
-            margin: 20px 20px 20px 5px;
+            margin: 20px 15px 20px 5px;
           }
           .paid{
+            .date-field{
+              margin-left: 50px;
+              input{
+                width: 200px;
+              }
+            }
             margin: 10px 0;
+            .wday-check-box{
+              label{
+                font-size: 20px;
+              }
+              input{
+                width: 13px;
+                height: 15px;
+              }
+            }
           }
         }
       }

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -34,12 +34,15 @@
           <label><%= form.radio_button :classification, :date%>日にち指定のタスク</label>
           <p>※指定した日にちにタスクが<br>
             &emsp;自動で追加されます。<font color="red">（有料）</font></p>
+          <div class="date-field">
+            <%= form.date_field :date %>
+          </div>
         </div>
         <div class="paid">
           <label><%= form.radio_button :classification, :week%>曜日指定のタスク</label>
           <p>※指定した曜日にタスクが<br>
             &emsp;自動で追加されます。<font color="red">（有料）</font></p>
-          <div>
+          <div class="wday-check-box">
             <label>
               <%= form.check_box :monday, {}, "true", "false" %>月
             </label>

--- a/db/migrate/20230724072359_add_date_to_weeklies.rb
+++ b/db/migrate/20230724072359_add_date_to_weeklies.rb
@@ -1,0 +1,5 @@
+class AddDateToWeeklies < ActiveRecord::Migration[7.0]
+  def change
+    add_column :weeklies, :date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_18_072137) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_24_072359) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -88,6 +88,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_18_072137) do
     t.boolean "friday", default: false, null: false
     t.boolean "saturday", default: false, null: false
     t.boolean "sunday", default: false, null: false
+    t.date "date"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"


### PR DESCRIPTION
【背景】
　未来のタスク、締め切りのあるタスクなど自動でその日に追加になるようにして利便性を向上させる。

【内容】
　タスク追加画面（posts/new.html.erb）の日にち選択は、date_fieldを使ってカレンダー選択にする。[b0c240f](https://github.com/kazuki-01/family/pull/16/commits/b0c240f76966661fd217e9ef0e6f9b10e58bef5e)
　weeklyテーブルにdateカラムを作成して、日にちデータを入れるようにする。　[427a4e2](https://github.com/kazuki-01/family/pull/16/commits/427a4e2f1a0d3898541fe84cc1ecfa64cb9c5906)