### PR TITLE
【見て！】groupsテーブルの作成

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,0 +1,2 @@
+class GroupsController < ApplicationController
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -21,9 +21,13 @@
   
     # POST /users
     def create
+      group = Group.new(group_params)
+      group.save
       Rails.logger.debug('aaaaa')
       super
       Rails.logger.debug('bbbbb')
+      @user.group_id = group.id
+      @user.save
     end
   
     # GET /users/edit
@@ -55,7 +59,11 @@
     private
 
     def user_params
-      params.require(:user).permit(:user_icon, :name, :email, :password, :password_confirmation)
+      params.require(:user).permit(:user_icon, :name, :email, :password, :password_confirmation, group_id)
+    end
+
+    def group_params
+      params.require(:user).permit(:group_name, :paid)
     end
 
     protected

--- a/app/helpers/groups_helper.rb
+++ b/app/helpers/groups_helper.rb
@@ -1,0 +1,2 @@
+module GroupsHelper
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,0 +1,2 @@
+class Group < ApplicationRecord
+end

--- a/db/migrate/20230809135952_create_groups.rb
+++ b/db/migrate/20230809135952_create_groups.rb
@@ -1,0 +1,10 @@
+class CreateGroups < ActiveRecord::Migration[7.0]
+  def change
+    create_table :groups do |t|
+      t.string :group_name, default: 'ファミリーネーム'
+      t.boolean :paid, default: false, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230810132748_add_group_id_to_groups.rb
+++ b/db/migrate/20230810132748_add_group_id_to_groups.rb
@@ -1,0 +1,5 @@
+class AddGroupIdToGroups < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :group_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_30_043828) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_09_135952) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -55,6 +55,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_30_043828) do
     t.integer "user_id", null: false
     t.integer "labor", null: false
     t.string "classification", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "groups", force: :cascade do |t|
+    t.string "group_name", default: "ファミリーネーム"
+    t.boolean "paid", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_08_09_135952) do
+ActiveRecord::Schema[7.0].define(version: 2023_08_10_132748) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -91,6 +91,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_09_135952) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name"
+    t.integer "group_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/test/controllers/groups_controller_test.rb
+++ b/test/controllers/groups_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class GroupsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/groups.yml
+++ b/test/fixtures/groups.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  group_name: MyString
+  group_id: 1
+  paid: false
+
+two:
+  group_name: MyString
+  group_id: 1
+  paid: false

--- a/test/models/group_test.rb
+++ b/test/models/group_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class GroupTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
【背景】
家族やグループでタスクを共有するときに
タスクなどの内容をグループの人のみに表示させたい。

【内容】
ユーザー登録時に、グループテーブルも同時に作られて
作られたグループのidを、登録したuserのgroup_idカラムに登録する。

その後グループidが同じユーザーの投稿のみグループ内で表示されるようにする。

【確認して欲しい】
今ある知識をふり絞って、user登録時に、groupsテーブルの作成と
usersテーブルのgroup_idも登録されるようにコードを記述したが
これで問題ないですか？正常に登録はなります！ユーザーの登録は、deviseを使用中。
　　　↓
[1f61a5d](https://github.com/kazuki-01/family/pull/22/commits/1f61a5d397c1fb152ea92ca17c373c220e46d4ae)
